### PR TITLE
fix: remove ScorableXBlockMixin to resolve completion tracking issue

### DIFF
--- a/pdf/pdf.py
+++ b/pdf/pdf.py
@@ -16,7 +16,6 @@ loader = ResourceLoader(__name__)
 @XBlock.wants('settings')
 @XBlock.needs('i18n')
 class PdfBlock(
-    ScorableXBlockMixin,
     XBlock,
     XBlockWithSettingsMixin,
     ThemableXBlockMixin


### PR DESCRIPTION
**Description**

- Removed `ScorableXBlockMixin` from PdfXBlock to resolve completion tracking issues. As we are not using grading in PdfXBlock, it is safe to remove this mixin.

**Jira**

- https://whoacademy.atlassian.net/browse/UC-253

**Screenshot**

<img width="1471" height="411" alt="image" src="https://github.com/user-attachments/assets/91f7c6c1-7c69-4573-8216-e7c8e430a4dd" />

